### PR TITLE
fix: add invalid char (#33)

### DIFF
--- a/client/ClientManager.cpp
+++ b/client/ClientManager.cpp
@@ -66,7 +66,7 @@ bool	ClientManager::isValidNickname(std::string nick)
 		return (false);
 	for (std::string::iterator it = nick.begin(); it != nick.end(); it++)
 	{
-		if (!std::isprint(*it))
+		if (!std::isprint(*it) || *it == ',')
 			return (false);
 	}
 	


### PR DESCRIPTION
ISSUE(#33)

':'은 parsing단에서 이미 잘라서 trailing으로 들고 있는 바람에 nick 까지 오지 않네요 ㅎㅎ..
에러는 아니니까 그냥 두는 것도 나쁘지 않을 것 같습니다.

요것도 NICK 명령어 자체에서는 상관이 없는 부분이지만 다른 명령어를 받을 때 param을 ','로 구분하여 받는 경욱 ㅏ있으니 ','에 대해서는 검사를 하고 에러를 출력하도록 했습니다.