### PR TITLE
fix: exit when system error occurs (#43)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,9 +8,16 @@ int	main(int argc, char **argv)
 		return (1);
 	}
 
+	try {
 	Server server;
 	server.init(argv[1], argv[2]);
 	server.run();
+	}
+	catch (std::exception &e)
+	{
+		std::cerr << e.what() << std::endl;
+		exit(EXIT_FAILURE);
+	}
 
 	return (0);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -9,9 +9,9 @@ int	main(int argc, char **argv)
 	}
 
 	try {
-	Server server;
-	server.init(argv[1], argv[2]);
-	server.run();
+		Server server;
+		server.init(argv[1], argv[2]);
+		server.run();
 	}
 	catch (std::exception &e)
 	{

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -7,18 +7,10 @@ Server::Server()
 
 void Server::init(char* port, char* password)
 {
-	try
-	{
-		server_socket_.bind(port);
-		server_socket_.listen();
-		if ((kqueue_ = kqueue()) == -1)
-			throw std::runtime_error("Kqueue error");
-	}
-	catch (std::exception &e)
-	{
-		std::cerr << e.what() << std::endl;
-		exit(EXIT_FAILURE);
-	}
+	server_socket_.bind(port);
+	server_socket_.listen();
+	if ((kqueue_ = kqueue()) == -1)
+		throw std::runtime_error("Kqueue error");
 
 	addSocket(server_socket_.getSocket());
 

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -19,12 +19,13 @@ class Server {
 		void process(void);
 		void addSocket(int socket);
 
+		void successHandler(int socket);
+		void errorHandler(int socket);
+		
 	public:
 		Server();
 		void init(char* port, char* password);
 		void run(void);
-		void successHandler(int socket);
-		void errorHandler(int socket);
 };
 
 #endif


### PR DESCRIPTION
ISSUE(#43)

bind와 같은 명백한 system error와 사용자의 포트로 인한 error를 따로 처리해보려고 했으나 포트 번호가 잘못되었을 때 fcntl에서 에러가 발생하고 throw를 하는 순간 서버가 꺼져서 아예 메인 문에서 try ,catch로 에러를 잡고 exit(EXIT_FAILURE)를 하는 것이 더 안전한 방법이라고 생각하여 바꿨습니다. 

코드 한번 보시고 논의가 더 필요할 듯 하면 코멘트 남겨주세요