### PR TITLE
fix: do not msg when target_client is not authenticated (#56)

### DIFF
--- a/packet/Commands.cpp
+++ b/packet/Commands.cpp
@@ -182,7 +182,7 @@ void	PacketManager::privmsg(struct Packet& packet)
 		else
 		{
 			Client *target_client = client_manager_.getClientByNick(*it);
-			if (!target_client)
+			if (!target_client || !target_client->getIsAuthenticated())
 			{
 				packet_maker_->ErrNoSuchNick(packet, *it);
 				return ;


### PR DESCRIPTION
ISSUE (#56 )

target_client의 isAuthenticated 변수를 검사해서 아직 등록되지 않은 사용자일 경우 msg를 보내지 않습니다