### PR TITLE
fix: quit client when try to change nick who isn't authenticated (#58)

### DIFF
--- a/packet/Commands.cpp
+++ b/packet/Commands.cpp
@@ -82,7 +82,7 @@ void	PacketManager::nick(struct Packet& packet)
 			client->setIsAuthenticated(true);
 		}
 	}
-	else
+	else if (nick_client->getIsAuthenticated())
 	{
 		Message message = packet_maker_->NickSuccess(packet);
 		
@@ -97,6 +97,11 @@ void	PacketManager::nick(struct Packet& packet)
 
 			packet_maker_->sendPacket(message, (*it)->getChannelName(), new_nick);
 		}
+	}
+	else
+	{
+		packet_maker_->ErrNotRegistered(packet);
+		quit(packet);
 	}
 }
 


### PR DESCRIPTION
ISSUE(#58 )

authenticated 되지 않은 클라이언트가 nick 변경을 시도 한 경우 ERR 메시지 출력 후 연결 끊어버렸습니다.
(챗지피티가 그러래요)