### PR TITLE
feat: check hostIP always (because '*') (#62)

### DIFF
--- a/packet/Commands.cpp
+++ b/packet/Commands.cpp
@@ -132,7 +132,10 @@ void	PacketManager::user(struct Packet& packet)
 
 	client->setUserName(packet.message.getParams()[0]);
 	client->setServerName(packet.message.getParams()[1]);
-	client->setHostName(packet.message.getParams()[2]);
+	struct sockaddr_in clnt_addr;
+    socklen_t size = sizeof(clnt_addr);
+    getsockname(packet.client_socket, &(struct sockaddr& )clnt_addr, &size);
+    client->setHostName(inet_ntoa(clnt_addr.sin_addr));
 	client->setRealName(packet.message.getTrailing());
 
 	if (client->getNickName() != "")


### PR DESCRIPTION
ISSUE (#62)
```
struct sockaddr_in clnt_addr;
socklen_t size = sizeof(clnt_addr);
getsockname(packet.client_socket, &(struct sockaddr& )clnt_addr, &size);
client->setHostName(inet_ntoa(clnt_addr.sin_addr));
```

ip를 서버 단에서 체크하고 hostName에 넘겨주는 것으로 변경했습니다.
-> USER user 0 * :realname이 들어왔을 때 127.0.0.1로 hostName을 설정합니다
